### PR TITLE
Revert "Stop using full-core"

### DIFF
--- a/minutus-mrbgem-template/build_config.rb
+++ b/minutus-mrbgem-template/build_config.rb
@@ -1,6 +1,6 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   
-  conf.gembox 'default'
+  conf.gembox 'full-core'
   conf.gem github: 'matsumoto-r/mruby-mrbgem-template'
 end

--- a/minutus-mrbgem-template/src/templates/mrbgem.rake
+++ b/minutus-mrbgem-template/src/templates/mrbgem.rake
@@ -14,6 +14,4 @@ MRuby::Gem::Specification.new('{{ mrbgem_name }}') do |spec|
   if RbConfig::CONFIG['host_os'].downcase.include?('darwin')
     spec.linker.flags << '-framework CoreFoundation'
   end
-
-  spec.add_dependency 'mruby-error'
 end

--- a/minutus/build_config.rb
+++ b/minutus/build_config.rb
@@ -1,6 +1,6 @@
 MRuby::Build.new do |conf|
   conf.toolchain
-  conf.gembox 'default'
+  conf.gembox 'full-core'
   conf.enable_bintest
   conf.enable_test
 end


### PR DESCRIPTION
This reverts commit 72f68140d5c77c336ecd68832883d0ca68d4353d.

Fix for https://github.com/genya0407/minutus/pull/8#issuecomment-1872205638