### PR TITLE
Fix unnecessary rebuilds triggered by bumping bridge.c timestamp

### DIFF
--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -127,7 +127,14 @@ fn compile_bridge() -> Result<()> {
         eprintln!("{}", String::from_utf8(output.stderr)?);
         return Err(anyhow!("Failed to execute command"));
     }
-    std::fs::write(out_dir.join("bridge.c"), output.stdout)?;
+
+    let existing_bridge = std::fs::read(out_dir.join("bridge.c"));
+    let bridge_changed = existing_bridge
+        .map(|existing_bridge| existing_bridge != output.stdout)
+        .unwrap_or(true);
+    if bridge_changed {
+        std::fs::write(out_dir.join("bridge.c"), output.stdout)?;
+    }
 
     // generate binding
     println!("Start generating binding");


### PR DESCRIPTION
I'm not sure if this was surfaced by a new cargo version, but disabling mold and sccache doesn't seem to solve the problem. With this change I no longer see minutus rebuilds every time I build my crate.