### PR TITLE
feat: add preliminary Windows support and mruby_dir feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Following versions are supported:
 
 You can also use mruby's `master` branch, but it is not tested.
 
+If you need to customize a specific version (such as a specific tag), you can do so via `mruby_dir`. See "Local Dir" for details.
+
 If the version is not specified on Cargo.toml,
 the latest supported stable version is used.
 
@@ -208,6 +210,60 @@ minutus = { version = "*", features = ["mruby_3_2_0"] }
 # Use master branch
 minutus = { version = "*", features = ["mruby_master"] }
 ```
+
+### Local Dir
+
+Use a local directory instead of a remote Git repository.
+
+```toml
+# Cargo.toml
+#
+[dependencies]
+minutus = { version = "*", features = ["mruby_dir"] }
+```
+
+#### Example
+
+```shell
+# POSIX-sh
+#
+cd /tmp
+tag="240412a29080f775fabf97e56fc158b7249367e1"
+curl -Lfo mruby.tgz "https://github.com/mruby/mruby/archive/${tag}.tar.gz"
+
+tar -xf mruby.tgz
+mv mruby-$tag mruby-local-dir
+```
+
+**build:**
+
+Modify your project's `Rakefile`.
+
+```ruby
+# Rakefile
+#
+file :mruby do
+  #sh "git clone --depth=1 https://github.com/mruby/mruby.git"
+  local_dir = "/tmp/mruby-local-dir"
+  unless Dir.exist?("mruby")
+    FileUtils.cp_r(local_dir, "mruby")
+  end
+  # ...
+```
+
+Next, you can pass the specified path using the **MINUTUS_MRUBY_DIR** environment variable.
+
+```sh
+# POSIX-sh
+#
+env MINUTUS_MRUBY_DIR=/tmp/mruby-local-dir cargo b -rvv
+```
+
+## Cross-Platform Support
+
+**minutus** primarily supports Unix-like systems.
+
+If you encounter issues in a Windows MSVC environment, try using **msys2** and the `*-pc-windows-gnu` target.
 
 ## Naming
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Next, you can pass the specified path using the **MINUTUS_MRUBY_DIR** environmen
 env MINUTUS_MRUBY_DIR=/tmp/mruby-local-dir cargo b -rvv
 ```
 
-## Cross-Platform Support
+## Supported Platforms
 
 **minutus** primarily supports Unix-like systems.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ Following versions are supported:
 
 You can also use mruby's `master` branch, but it is not tested.
 
-If you need to use mruby versions not listed above (e.g., a specific tag or a fork), you can do so via `mruby_dir` feature. See "mruby_dir" section for details.
+If you need to use mruby versions not listed above (e.g., a specific tag or a fork),
+you can do so via `mruby_dir` feature.
+See "mruby_dir" section for details.
 
 If the version is not specified on Cargo.toml,
 the latest supported stable version is used.
@@ -274,7 +276,8 @@ Finally, run `rake compile` to build your project.
 
 **minutus** primarily supports Unix-like systems.
 
-If you encounter issues in a Windows MSVC environment, try using **msys2** and the `*-pc-windows-gnu` target.
+If you encounter issues in a Windows MSVC environment,
+try using **msys2** and the `*-pc-windows-gnu` target.
 
 ## Naming
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Modify your project's `Rakefile`.
 #
 # ...
 # The value of `MINUTUS_MRUBY_DIR` is the path to the source code of mruby.
-ENV["minutus_mruby_dir".upcase] = "/tmp/mruby-master"
+ENV["minutus_mruby_dir".upcase] = "/tmp/mruby-src-dir"
 
 file :mruby do
   #sh "git clone --depth=1 https://github.com/mruby/mruby.git"

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Following versions are supported:
 
 You can also use mruby's `master` branch, but it is not tested.
 
-If you need to customize a specific version (such as a specific tag), you can do so via `mruby_dir`. See "Local Dir" for details.
+If you need to use mruby versions not listed above (e.g., a specific tag or a fork), you can do so via `mruby_dir` feature. See "mruby_dir" section for details.
 
 If the version is not specified on Cargo.toml,
 the latest supported stable version is used.
@@ -211,9 +211,9 @@ minutus = { version = "*", features = ["mruby_3_2_0"] }
 minutus = { version = "*", features = ["mruby_master"] }
 ```
 
-### Local Dir
+### mruby_dir
 
-Use a local directory instead of a remote Git repository.
+When `mruby_dir` feature is specified, minutus uses your local directory as `mruby`.
 
 ```toml
 # Cargo.toml
@@ -232,7 +232,7 @@ tag="240412a29080f775fabf97e56fc158b7249367e1"
 curl -Lfo mruby.tgz "https://github.com/mruby/mruby/archive/${tag}.tar.gz"
 
 tar -xf mruby.tgz
-mv mruby-$tag mruby-local-dir
+mv mruby-$tag mruby-src-dir
 ```
 
 **build:**
@@ -242,22 +242,33 @@ Modify your project's `Rakefile`.
 ```ruby
 # Rakefile
 #
+# ...
+# The value of `MINUTUS_MRUBY_DIR` is the path to the source code of mruby.
+ENV["minutus_mruby_dir".upcase] = "/tmp/mruby-master"
+
 file :mruby do
   #sh "git clone --depth=1 https://github.com/mruby/mruby.git"
-  local_dir = "/tmp/mruby-local-dir"
+  #
   unless Dir.exist?("mruby")
-    FileUtils.cp_r(local_dir, "mruby")
+    FileUtils.cp_r(ENV["minutus_mruby_dir".upcase], "mruby")
   end
   # ...
 ```
 
-Next, you can pass the specified path using the **MINUTUS_MRUBY_DIR** environment variable.
+Modify **mrbgem.rake**:
 
-```sh
-# POSIX-sh
+```ruby
+# mrbgem.rake
 #
-env MINUTUS_MRUBY_DIR=/tmp/mruby-local-dir cargo b -rvv
+MRuby::Gem::Specification.new('mruby-[your-project]') do |spec|
+# ...
+# If you encounter errors during the build process,
+# you can try adding the `-vv` flag to Cargo for more detailed output.
+sh "cd #{__dir__} && cargo build -vv --release"
+# ...
 ```
+
+Finally, run `rake compile` to build your project.
 
 ## Supported Platforms
 

--- a/minutus-mruby-build-utils/Cargo.toml
+++ b/minutus-mruby-build-utils/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/genya0407/minutus"
 [dependencies]
 anyhow = "1.*"
 bytes = "1.*"
-tar = "0.4.40"
-reqwest = { version = "0.11.23", features = ["blocking"] }
+tar = "0.4.44"
+reqwest = { version = "0.12.24", features = ["blocking"] }
 flate2 = "1.*"
 cc = "1.*"
+fs_extra = "1.3.0"

--- a/minutus-mruby-build-utils/src/lib.rs
+++ b/minutus-mruby-build-utils/src/lib.rs
@@ -108,9 +108,16 @@ impl MRubyManager {
         }
 
         if let Some(src_dir) = self.copy_mruby_from {
-            mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|_| {
-        panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby")
-      });
+            let copied =
+        mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|_| {
+          panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby")
+        });
+            if copied == 0 {
+                panic!(
+                    r#"No files were copied into the `mruby` directory.
+          Please make sure that mruby src dir is not an empty directory."#
+                )
+            }
         }
 
         build_mruby(&workdir, &build_config);
@@ -133,22 +140,18 @@ fn build_mruby(workdir: &Path, path: &Path) {
 }
 
 fn link_mruby(workdir: &Path) {
-    let mrb_cfg_bin = workdir
-        // On Windows, you don't need to manually change path separators "/" to "\\",
-        // because Rust std handles them automatically.
-        //
-        // Note: Modern Unix-like are compatible with the POSIX path separator `/`.
-        .join("mruby/bin/mruby-config");
+    // On Windows, you don't need to manually change path separators "/" to "\\",
+    // because Rust std handles them automatically.
+    //
+    // Note: Modern Unix-like are compatible with the POSIX path separator `/`.
+    let mrb_cfg_bin = workdir.join("mruby/bin/mruby-config");
 
-    #[allow(unreachable_patterns)]
-    let mruby_config = match mrb_cfg_bin {
-        #[cfg(windows)]
-        p => Some(p.with_extension("bat")).filter(|x| x.exists()),
-        #[cfg(not(windows))]
-        p if p.exists() => Some(p),
-        _ => None,
+    let mruby_config =
+        if cfg!(windows) { mrb_cfg_bin.with_extension("bat") } else { mrb_cfg_bin };
+
+    if !mruby_config.exists() {
+        panic!(r#"The `mruby-config` executable file does not exist!"#);
     }
-    .expect(r#"The `mruby-config` executable file does not exist!"#);
 
     let ldflags_before_libs = run_command(
         workdir,

--- a/minutus-mruby-build-utils/src/lib.rs
+++ b/minutus-mruby-build-utils/src/lib.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
 
+mod mruby_dir;
+
 /// Helper for building and linking libmruby.
 #[derive(Debug)]
 pub struct MRubyManager {
@@ -10,6 +12,7 @@ pub struct MRubyManager {
     do_link: bool,
     build_config: Option<PathBuf>,
     do_download: bool,
+    copy_mruby_from: Option<PathBuf>,
 }
 
 impl Default for MRubyManager {
@@ -20,6 +23,7 @@ impl Default for MRubyManager {
             do_link: true,
             build_config: None,
             do_download: true,
+            copy_mruby_from: None,
         }
     }
 }
@@ -50,6 +54,18 @@ impl MRubyManager {
         self
     }
 
+    /// Set custom `mruby_dir`
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// MRubyManager::new().copy_mruby_from("/path/to/mruby-src-dir").run()
+    /// ```
+    pub fn copy_mruby_from<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.copy_mruby_from = Some(path.into());
+        self
+    }
+
     /// Whether the builder should build/link `libmruby.a` or not. The default is
     /// `true`.
     ///
@@ -74,18 +90,29 @@ impl MRubyManager {
     /// Run the task.
     pub fn run(self) {
         let workdir = self.workdir.unwrap_or_else(|| {
-            let out_dir = std::env::var("OUT_DIR")
-                .expect(r#"Could not fetch "OUT_DIR" environment variable."#);
-            Path::new(&out_dir).to_path_buf()
+            std::env::var("OUT_DIR")
+                .expect(r#"Could not fetch "OUT_DIR" environment variable."#)
+                .into()
         });
-        let mruby_version = self.mruby_version.expect("mruby_version is not set.");
+
         let build_config = self
             .build_config
-            .unwrap_or(Path::new("default").to_path_buf()); // see: https://github.com/mruby/mruby/blob/3.2.0/doc/guides/compile.md#build
+            .unwrap_or_else(|| "default".into()); // see: https://github.com/mruby/mruby/blob/3.2.0/doc/guides/compile.md#build
 
         if self.do_download {
+            let mruby_version = self
+                .mruby_version
+                .expect("mruby_version is not set.");
+
             download_mruby(&workdir, &mruby_version);
         }
+
+        if let Some(src_dir) = self.copy_mruby_from {
+            mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|_| {
+        panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby")
+      });
+        }
+
         build_mruby(&workdir, &build_config);
 
         if self.do_link {
@@ -95,12 +122,7 @@ impl MRubyManager {
 }
 
 fn build_mruby(workdir: &Path, path: &Path) {
-    let rake = match () {
-        #[cfg(windows)]
-        () => "rake.bat",
-        #[cfg(not(windows))]
-        _ => "rake",
-    };
+    let rake = if cfg!(windows) { "rake.bat" } else { "rake" };
 
     let c = &[
         rake,
@@ -121,23 +143,23 @@ fn link_mruby(workdir: &Path) {
     #[allow(unreachable_patterns)]
     let mruby_config = match mrb_cfg_bin {
         #[cfg(windows)]
-        p => ["bat", "exe"]
-            .iter()
-            .map(|ext| p.with_extension(ext))
-            .find(|x| x.exists()),
+        p => Some(p.with_extension("bat")).filter(|x| x.exists()),
         #[cfg(not(windows))]
         p if p.exists() => Some(p),
         _ => None,
     }
-    .expect("The mruby-config file does not exist!");
+    .expect(r#"The `mruby-config` executable file does not exist!"#);
 
     let ldflags_before_libs = run_command(
         workdir,
         &[mruby_config.to_str().unwrap(), "--ldflags-before-libs"],
     )
     .unwrap();
-    let ldflags = run_command(workdir, &[mruby_config.to_str().unwrap(), "--ldflags"]).unwrap();
-    let libs = run_command(workdir, &[mruby_config.to_str().unwrap(), "--libs"]).unwrap();
+    let ldflags =
+        run_command(workdir, &[mruby_config.to_str().unwrap(), "--ldflags"])
+            .unwrap();
+    let libs =
+        run_command(workdir, &[mruby_config.to_str().unwrap(), "--libs"]).unwrap();
     println!(
         "cargo:rustc-flags={} {} {}",
         ldflags_before_libs.trim(),
@@ -153,9 +175,13 @@ pub fn download_mruby(workdir: &Path, mruby_version: &str) {
     }
 
     let url = match mruby_version {
-        "master" => "https://github.com/mruby/mruby/archive/refs/heads/master.tar.gz".into(),
+        "master" => {
+            "https://github.com/mruby/mruby/archive/refs/heads/master.tar.gz".into()
+        }
         _ => {
-            format!("https://github.com/mruby/mruby/archive/refs/tags/{mruby_version}.tar.gz")
+            format!(
+        "https://github.com/mruby/mruby/archive/refs/tags/{mruby_version}.tar.gz"
+      )
         }
     };
 

--- a/minutus-mruby-build-utils/src/lib.rs
+++ b/minutus-mruby-build-utils/src/lib.rs
@@ -1,7 +1,9 @@
-use anyhow::{anyhow, Result};
 use std::path::{Path, PathBuf};
 
+use anyhow::{bail, Result};
+
 /// Helper for building and linking libmruby.
+#[derive(Debug)]
 pub struct MRubyManager {
     workdir: Option<PathBuf>,
     mruby_version: Option<String>,
@@ -10,10 +12,8 @@ pub struct MRubyManager {
     do_download: bool,
 }
 
-impl MRubyManager {
-    /// Construct a new instance of a blank set of configuration.
-    /// This builder is finished with the [run][`MRubyManager::run()`] function.
-    pub fn new() -> Self {
+impl Default for MRubyManager {
+    fn default() -> Self {
         Self {
             workdir: None,
             mruby_version: None,
@@ -21,6 +21,14 @@ impl MRubyManager {
             build_config: None,
             do_download: true,
         }
+    }
+}
+
+impl MRubyManager {
+    /// Construct a new instance of a blank set of configuration.
+    /// This builder is finished with the [run][`MRubyManager::run()`] function.
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Set workdir. The default is `"OUT_DIR"` environment variable.
@@ -35,15 +43,18 @@ impl MRubyManager {
         self
     }
 
-    /// Set custom `build_config.rb`. If not set, the builder uses mruby's default config.
+    /// Set custom `build_config.rb`. If not set, the builder uses mruby's default
+    /// config.
     pub fn build_config(mut self, build_config: &Path) -> Self {
         self.build_config = Some(build_config.to_path_buf());
         self
     }
 
-    /// Whether the builder should build/link `libmruby.a` or not. The default is `true`.
+    /// Whether the builder should build/link `libmruby.a` or not. The default is
+    /// `true`.
     ///
-    /// If set to `false`, builder does not build nor link libmruby. So you have to do it by yourself.
+    /// If set to `false`, builder does not build nor link libmruby. So you have
+    /// to do it by yourself.
     ///
     /// If you embed mruby into your Rust project, this should be `true`.
     pub fn link(mut self, doit: bool) -> Self {
@@ -51,7 +62,8 @@ impl MRubyManager {
         self
     }
 
-    /// Whether the builder should internally download mruby source code or not. The default is `true`.
+    /// Whether the builder should internally download mruby source code or not.
+    /// The default is `true`.
     ///
     /// If set to `false` you have to place `$OUT_DIR/mruby` by yourself.
     pub fn download(mut self, doit: bool) -> Self {
@@ -63,13 +75,10 @@ impl MRubyManager {
     pub fn run(self) {
         let workdir = self.workdir.unwrap_or_else(|| {
             let out_dir = std::env::var("OUT_DIR")
-                .expect("Could not fetch \"OUT_DIR\" environment variable.");
+                .expect(r#"Could not fetch "OUT_DIR" environment variable."#);
             Path::new(&out_dir).to_path_buf()
         });
-        let mruby_version = self
-            .mruby_version
-            .map(String::from)
-            .expect("mruby_version is not set.");
+        let mruby_version = self.mruby_version.expect("mruby_version is not set.");
         let build_config = self
             .build_config
             .unwrap_or(Path::new("default").to_path_buf()); // see: https://github.com/mruby/mruby/blob/3.2.0/doc/guides/compile.md#build
@@ -86,8 +95,15 @@ impl MRubyManager {
 }
 
 fn build_mruby(workdir: &Path, path: &Path) {
+    let rake = match () {
+        #[cfg(windows)]
+        () => "rake.bat",
+        #[cfg(not(windows))]
+        _ => "rake",
+    };
+
     let c = &[
-        "rake",
+        rake,
         "all",
         &format!("MRUBY_CONFIG={}", path.to_string_lossy()),
     ];
@@ -95,7 +111,26 @@ fn build_mruby(workdir: &Path, path: &Path) {
 }
 
 fn link_mruby(workdir: &Path) {
-    let mruby_config = workdir.join("mruby").join("bin").join("mruby-config");
+    let mrb_cfg_bin = workdir
+        // On Windows, you don't need to manually change path separators "/" to "\\",
+        // because Rust std handles them automatically.
+        //
+        // Note: Modern Unix-like are compatible with the POSIX path separator `/`.
+        .join("mruby/bin/mruby-config");
+
+    #[allow(unreachable_patterns)]
+    let mruby_config = match mrb_cfg_bin {
+        #[cfg(windows)]
+        p => ["bat", "exe"]
+            .iter()
+            .map(|ext| p.with_extension(ext))
+            .find(|x| x.exists()),
+        #[cfg(not(windows))]
+        p if p.exists() => Some(p),
+        _ => None,
+    }
+    .expect("The mruby-config file does not exist!");
+
     let ldflags_before_libs = run_command(
         workdir,
         &[mruby_config.to_str().unwrap(), "--ldflags-before-libs"],
@@ -117,13 +152,11 @@ pub fn download_mruby(workdir: &Path, mruby_version: &str) {
         return;
     }
 
-    let url = if mruby_version == "master" {
-        String::from("https://github.com/mruby/mruby/archive/refs/heads/master.tar.gz")
-    } else {
-        format!(
-            "https://github.com/mruby/mruby/archive/refs/tags/{}.tar.gz",
-            mruby_version
-        )
+    let url = match mruby_version {
+        "master" => "https://github.com/mruby/mruby/archive/refs/heads/master.tar.gz".into(),
+        _ => {
+            format!("https://github.com/mruby/mruby/archive/refs/tags/{mruby_version}.tar.gz")
+        }
     };
 
     let resp = reqwest::blocking::get(url).unwrap();
@@ -133,31 +166,29 @@ pub fn download_mruby(workdir: &Path, mruby_version: &str) {
         flate2::read::GzDecoder::new(tar_gz.reader())
     };
     let mut archive = tar::Archive::new(tar);
-    archive.unpack(&workdir).unwrap();
+    archive.unpack(workdir).unwrap();
 
     std::fs::rename(
-        workdir.join(format!("mruby-{}", mruby_version)),
+        workdir.join(format!("mruby-{mruby_version}")),
         workdir.join("mruby"),
     )
     .unwrap();
 }
 
 fn run_command(current_dir: &Path, cmd: &[&str]) -> Result<String> {
-    println!("Start: {:?}", cmd);
+    println!("Start: {cmd:?}");
 
     let output = std::process::Command::new(cmd[0])
         .args(&cmd[1..])
         .current_dir(current_dir)
         .output()?;
 
-    if output.status.success() {
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    } else {
-        Err(anyhow!(format!(
-            "Executing {:?} failed: {}, {}",
-            cmd,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        )))
+    let [stdout, stderr] = [&output.stdout, &output.stderr] //
+        .map(|buf| String::from_utf8_lossy(buf));
+
+    if !output.status.success() {
+        bail!("Executing {cmd:?} failed!\n stdout: {stdout}\n stderr: {stderr}")
     }
+
+    Ok(stdout.into_owned())
 }

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -65,7 +65,7 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
 
     if target_dir.exists() {
         if dir_is_not_empty(&target_dir) {
-            println!("cargo:warning=Dir exists: {target_dir:?}");
+            eprintln!("[INFO] Dir exists: {target_dir:?}");
             // Do not use Ok(0) here.
             // Later, we might need to use Ok(n) to determine the number of bytes copied.
             // In some cases, OK(0) (i.e., copying an empty directory) may be considered a
@@ -79,7 +79,7 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
         println!("cargo:warning=Removing the existing directory: {target_dir:?}");
         fs::remove_dir_all(&target_dir)?
     }
-    println!("cargo:warning=src dir: {src_dir:?}, target dir: {target_dir:?}");
+    eprintln!("[INFO] src dir: {src_dir:?}, target dir: {target_dir:?}");
 
     // There's no need to check whether `src_dir` is an empty directory here;
     // instead, let the final caller handle the Err(_) & Ok(0).

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -65,13 +65,16 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
         .file_name()
         .ok_or_else(|| io::Error::other("Failed to get src_dir.file_name"))?;
 
-    // In UNIX-like `sh` ,
-    // running `cp -r /path/to/xx /out/mruby` behaves as follows:
+    // In UNIX-like systems' `sh`,
+    // running `cp -r /tmp/xx /out/mruby` behaves as follows:
     //
-    // - 1. If the `mruby` directory does not exist, `xx` will be renamed to `mruby`
-    //   implicitly.
-    // - 2. If the `mruby` directory exists, the `xx` directory will be copied into
-    //   `/out/mruby/xx`.
+    // - 1. If the `mruby` directory does not exist, the contents of `xx` will be
+    //   copied into a newly created directory named `mruby` automatically.
+    //  (/tmp/xx => /out/mruby)
+    //
+    // - 2. If the `mruby` directory exists, the directory xx will be copied into
+    //   /out/mruby/ as a subdirectory.
+    //  (/tmp/xx => /out/mruby/xx)
     //
     // The behavior of `fs_extra::dir::copy` is closer to the 2nd case:
     // it assumes the destination directory already exists.

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -74,7 +74,7 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
         }
         // An existing but empty mruby directory is a clear sign of a failed or
         // incomplete build.
-        // Perform cleanup at this stage to prevent issues with subsequent `fs::rename`
+        // Perform cleanup at this stage to prevent issues with subsequent `dir::copy`
         // operations.
         fs::remove_dir_all(&target_dir)?
     }

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -20,7 +20,9 @@ fn dir_is_not_empty<P: AsRef<Path>>(path: P) -> bool {
 }
 
 fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
-    let opts = CopyOptions::new().overwrite(true);
+    let opts = CopyOptions::new()
+        .overwrite(true)
+        .copy_inside(true);
 
     copy_dir(from, to, &opts).map_err(|e| {
         let err_msg = format!(
@@ -43,13 +45,32 @@ fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
 /// // src_dir => "{work_dir}/mruby"
 /// copy_to_mruby_dir(src_dir, &work_dir)?;
 /// ```
+///
+/// # Returns
+///
+/// This function returns either `io::ErrorKind::Other(msg)` or `Ok(u64)`.
+///
+/// When returning `Ok(n)`, `n` represents the amount of data transferred (in
+/// bytes).
+///
+/// - If `n = 0`, it means an empty directory was copied.
+/// - If `n >= 1`, it indicates that a non-empty directory was transferred
+///   (copied).
+///
+/// > Note: This function uses the special return value `Ok(1)` to indicate that
+/// > `target_dir` already exists and is not empty, but the function returned
+/// > early without performing any copy operation.
 pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u64> {
     let target_dir = work_dir.join("mruby");
 
     if target_dir.exists() {
         if dir_is_not_empty(&target_dir) {
             println!("cargo:warning=Dir exists: {target_dir:?}");
-            return Ok(0);
+            // Do not use Ok(0) here.
+            // Later, we might need to use Ok(n) to determine the number of bytes copied.
+            // In some cases, OK(0) (i.e., copying an empty directory) may be considered a
+            // failure. Therefore, we use `Ok(1)`.
+            return Ok(1);
         }
         // An existing but empty mruby directory is a clear sign of a failed or
         // incomplete build.
@@ -59,30 +80,7 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
     }
     println!("cargo:warning=src dir: {src_dir:?}, target dir: {target_dir:?}");
 
-    let status = try_to_copy_dir(src_dir, work_dir);
-
-    let src_dir_name = Path::new(src_dir)
-        .file_name()
-        .ok_or_else(|| io::Error::other("Failed to get src_dir.file_name"))?;
-
-    // In UNIX-like systems' `sh`,
-    // running `cp -r /tmp/xx /out/mruby` behaves as follows:
-    //
-    // - 1. If the `mruby` directory does not exist, the contents of `xx` will be
-    //   copied into a newly created directory named `mruby` automatically.
-    //  (/tmp/xx => /out/mruby)
-    //
-    // - 2. If the `mruby` directory exists, the directory xx will be copied into
-    //   /out/mruby/ as a subdirectory.
-    //  (/tmp/xx => /out/mruby/xx)
-    //
-    // The behavior of `fs_extra::dir::copy` is closer to the 2nd case:
-    // it assumes the destination directory already exists.
-    // Therefore, manual renaming is required.
-    //
-    // In other words:
-    // `dir::copy("/tmp/xx", "/out"); rename("/out/xx", "/out/mruby");`
-    fs::rename(work_dir.join(src_dir_name), target_dir) //
-        .inspect_err(|e| println!("Failed to rename to mruby;\n Err: {e}"))?;
-    status
+    // There's no need to check whether `src_dir` is an empty directory here;
+    // instead, let the final caller handle the Err(_) & Ok(0).
+    try_to_copy_dir(src_dir, &target_dir)
 }

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -1,0 +1,85 @@
+use std::{fs, io, path::Path};
+
+use fs_extra::dir::{copy as copy_dir, CopyOptions};
+
+/// Checks whether a directory is empty.
+///
+/// Consider the following scenario:
+///
+/// Suppose we need to build mruby. Although the mruby directory exists,
+/// it may contain no files at all.
+///
+/// In such cases, the build will inevitably fail.
+/// Knowing in advance whether the mruby directory is empty is crucial to
+/// ensuring the correctness of the build process.
+fn dir_is_not_empty<P: AsRef<Path>>(path: P) -> bool {
+    fs::read_dir(path)
+        .ok()
+        .and_then(|mut entries| entries.next())
+        .is_some()
+}
+
+fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
+    let opts = CopyOptions::new().overwrite(true);
+
+    copy_dir(from, to, &opts).map_err(|e| {
+        let err_msg = format!(
+            "Failed to copy directory.
+      src dir: {from:?}, target dir: {to:?}
+      Err: {e}"
+        );
+        io::Error::other(err_msg)
+    })
+}
+
+/// Copies the "/path/to/mruby-src-dir" to "work_dir/mruby"
+///
+/// # Example
+///
+/// ```ignore
+/// let work_dir: PathBuf = env::var("OUT_DIR")?.into();
+/// let src_dir = Path::new("/tmp/mruby-3.4")
+///
+/// // src_dir => "{work_dir}/mruby"
+/// copy_to_mruby_dir(src_dir, &work_dir)?;
+/// ```
+pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u64> {
+    let target_dir = work_dir.join("mruby");
+
+    if target_dir.exists() {
+        if dir_is_not_empty(&target_dir) {
+            println!("cargo:warning=Dir exists: {target_dir:?}");
+            return Ok(0);
+        }
+        // An existing but empty mruby directory is a clear sign of a failed or
+        // incomplete build.
+        // Perform cleanup at this stage to prevent issues with subsequent `fs::rename`
+        // operations.
+        fs::remove_dir_all(&target_dir)?
+    }
+    println!("cargo:warning=src dir: {src_dir:?}, target dir: {target_dir:?}");
+
+    let status = try_to_copy_dir(src_dir, work_dir);
+
+    let src_dir_name = Path::new(src_dir)
+        .file_name()
+        .ok_or_else(|| io::Error::other("Failed to get src_dir.file_name"))?;
+
+    // In UNIX-like `sh` ,
+    // running `cp -r /path/to/xx /out/mruby` behaves as follows:
+    //
+    // - 1. If the `mruby` directory does not exist, `xx` will be renamed to `mruby`
+    //   implicitly.
+    // - 2. If the `mruby` directory exists, the `xx` directory will be copied into
+    //   `/out/mruby/xx`.
+    //
+    // The behavior of `fs_extra::dir::copy` is closer to the 2nd case:
+    // it assumes the destination directory already exists.
+    // Therefore, manual renaming is required.
+    //
+    // In other words:
+    // `dir::copy("/tmp/xx", "/out"); rename("/out/xx", "/out/mruby");`
+    fs::rename(work_dir.join(src_dir_name), target_dir) //
+        .inspect_err(|e| println!("Failed to rename to mruby;\n Err: {e}"))?;
+    status
+}

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -76,6 +76,7 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
         // incomplete build.
         // Perform cleanup at this stage to prevent issues with subsequent `dir::copy`
         // operations.
+        println!("cargo:warning=Removing the existing directory: {target_dir:?}");
         fs::remove_dir_all(&target_dir)?
     }
     println!("cargo:warning=src dir: {src_dir:?}, target dir: {target_dir:?}");

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -27,8 +27,8 @@ fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
     copy_dir(from, to, &opts).map_err(|e| {
         let err_msg = format!(
             "Failed to copy directory.
-      src dir: {from:?}, target dir: {to:?}
-      Err: {e}"
+            src dir: {from:?}, target dir: {to:?}
+            Err: {e}"
         );
         io::Error::other(err_msg)
     })

--- a/minutus/Cargo.toml
+++ b/minutus/Cargo.toml
@@ -18,6 +18,7 @@ cc = "1.*"
 bytes = "1.*"
 tar = "0.4.40"
 flate2 = "1.*"
+fs_extra = "1.3.0"
 
 [dependencies]
 minutus-macros = { version = "0.5.0", path = "../minutus-macros" }
@@ -29,3 +30,4 @@ mruby_3_2_0 = []
 mruby_3_3_0 = []
 mruby_master = []
 link_mruby = []
+mruby_dir = []

--- a/minutus/Cargo.toml
+++ b/minutus/Cargo.toml
@@ -16,9 +16,8 @@ anyhow = "1.*"
 bindgen = "0.72.1"
 cc = "1.*"
 bytes = "1.*"
-tar = "0.4.40"
+tar = "0.4.44"
 flate2 = "1.*"
-fs_extra = "1.3.0"
 
 [dependencies]
 minutus-macros = { version = "0.5.0", path = "../minutus-macros" }

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -1,4 +1,4 @@
-use std::{env, path::Path};
+use std::{env, fs, io, path::Path};
 
 use anyhow::{bail, Result};
 use minutus_mruby_build_utils::MRubyManager;
@@ -30,7 +30,7 @@ fn extract_mruby_source_code() -> Result<()> {
         return Ok(());
     }
 
-    let tar_gz = std::fs::read(archive_path)?;
+    let tar_gz = fs::read(archive_path)?;
     let tar = {
         use bytes::Buf;
         flate2::read::GzDecoder::new(tar_gz.reader())
@@ -38,7 +38,7 @@ fn extract_mruby_source_code() -> Result<()> {
     let mut archive = tar::Archive::new(tar);
     archive.unpack(workdir).unwrap();
 
-    std::fs::rename(
+    fs::rename(
         workdir.join(format!("mruby-{}", mruby_version())),
         workdir.join("mruby"),
     )?;
@@ -73,22 +73,50 @@ fn main() -> Result<()> {
 
     let out_dir = env::var("OUT_DIR")?;
     let build_config_copy = Path::new(&out_dir).join("build_config.rb");
-    std::fs::copy(
+    fs::copy(
         env::current_dir()?.join("build_config.rb"),
         &build_config_copy,
     )?;
 
     let do_link = env::var("CARGO_FEATURE_LINK_MRUBY").is_ok();
+    let do_download = match env::var("CARGO_FEATURE_MRUBY_DIR") {
+        Err(_) => true,
+        _ => match env::var("MINUTUS_MRUBY_DIR") {
+            Ok(dir) if dir.trim().is_empty() => true,
+            // copy_dir ok => No need to download.
+            // copy_dir err => need to download.
+            Ok(dir) => copy_to_mruby_outdir(&dir, &out_dir).is_err(),
+            _ => true,
+        },
+    };
+
     MRubyManager::new()
         .mruby_version(&mruby_version())
         .link(do_link)
         .build_config(&build_config_copy)
+        .download(do_download)
         .run();
     compile_bridge()?;
 
     println!("Finish build.rs");
 
     Ok(())
+}
+
+fn copy_to_mruby_outdir(dir: &str, out_dir: &str) -> fs_extra::error::Result<u64> {
+    use fs_extra::dir::{copy as copy_dir, CopyOptions};
+    let opts = CopyOptions::new().overwrite(true);
+    println!("cargo:warning=local mruby dir: {dir}");
+
+    let status = copy_dir(dir, out_dir, &opts).inspect_err(|e| {
+        println!("cargo:warning=Failed to copy dir;\n outdir: {out_dir};\n Err: {e}")
+    });
+
+    let dir_name = Path::new(out_dir)
+        .file_name()
+        .ok_or_else(|| io::Error::other("Failed to get out_dir.file_name"))?;
+    fs::rename(dir_name, "mruby")?;
+    status
 }
 
 fn mruby_version() -> String {
@@ -101,7 +129,9 @@ fn mruby_version() -> String {
         ))
         .is_ok()
         {
-            return version.to_lowercase().to_string();
+            return version
+                .to_lowercase()
+                .to_string();
         }
     }
     default.to_string()
@@ -127,19 +157,26 @@ fn compile_bridge() -> Result<()> {
         bail!("Failed to execute command")
     }
 
-    let existing_bridge = std::fs::read(out_dir.join("bridge.c"));
+    let existing_bridge = fs::read(out_dir.join("bridge.c"));
     let bridge_changed = existing_bridge
         .map(|existing_bridge| existing_bridge != output.stdout)
         .unwrap_or(true);
     if bridge_changed {
-        std::fs::write(out_dir.join("bridge.c"), output.stdout)?;
+        fs::write(out_dir.join("bridge.c"), output.stdout)?;
     }
 
     // generate binding
     println!("Start generating binding");
 
-    let mruby_include_path = Path::new(out_dir).join("mruby").join("include");
-    println!("include path: {}", mruby_include_path.to_str().unwrap());
+    let mruby_include_path = Path::new(out_dir)
+        .join("mruby")
+        .join("include");
+    println!(
+        "include path: {}",
+        mruby_include_path
+            .to_str()
+            .unwrap()
+    );
 
     let out_path = Path::new(out_dir).join("mruby.rs");
     let allowlist_types = &[
@@ -161,8 +198,17 @@ fn compile_bridge() -> Result<()> {
     ];
     let allowlist_functions = &["minu_.*", "mrb_raise", "mrb_get_args"];
     let bindings = bindgen::Builder::default()
-        .clang_arg(format!("-I{}", mruby_include_path.to_str().unwrap()))
-        .header(out_dir.join("bridge.c").to_string_lossy())
+        .clang_arg(format!(
+            "-I{}",
+            mruby_include_path
+                .to_str()
+                .unwrap()
+        ))
+        .header(
+            out_dir
+                .join("bridge.c")
+                .to_string_lossy(),
+        )
         .allowlist_type(allowlist_types.join("|"))
         .allowlist_function(allowlist_functions.join("|"))
         .layout_tests(false)

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -88,7 +88,8 @@ fn main() -> Result<()> {
 fn init_mruby_manager(build_config_copy: &Path) -> Result<MRubyManager> {
     let do_link = env::var("CARGO_FEATURE_LINK_MRUBY").is_ok();
 
-    let mut manager = MRubyManager::new() // We cannot provide proper `mruby_version` if mruby_dir feature is used.
+    let mut manager = MRubyManager::new()
+        // We cannot provide proper `mruby_version` if mruby_dir feature is used.
         .link(do_link)
         .build_config(build_config_copy);
 

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -103,11 +103,31 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+fn dir_is_not_empty<P: AsRef<Path>>(path: P) -> bool {
+    fs::read_dir(path)
+        .ok()
+        .and_then(|mut entries| entries.next())
+        .is_some()
+}
+
 fn copy_to_mruby_outdir(
     local_dir: &str,
     out_dir: &str,
 ) -> fs_extra::error::Result<u64> {
     use fs_extra::dir::{copy as copy_dir, CopyOptions};
+
+    let out_path = Path::new(out_dir);
+    let mruby_dir = out_path.join("mruby");
+
+    if mruby_dir.exists() {
+        match dir_is_not_empty(&mruby_dir) {
+            true => {
+                println!("cargo:warning=Dir exists: {mruby_dir:?}");
+                return Ok(0);
+            }
+            _ => fs::remove_dir_all(&mruby_dir)?,
+        }
+    }
 
     let opts = CopyOptions::new().overwrite(true);
     println!("cargo:warning=local mruby dir: {local_dir}");
@@ -115,7 +135,6 @@ fn copy_to_mruby_outdir(
     let status = copy_dir(local_dir, out_dir, &opts).inspect_err(|e| {
         println!("cargo:warning=Failed to copy dir;\n outdir: {out_dir};\n Err: {e}")
     });
-    let out_path = Path::new(out_dir);
 
     let dir_name = Path::new(local_dir)
         .file_name()
@@ -123,7 +142,7 @@ fn copy_to_mruby_outdir(
 
     println!("cargo:warning=out_dir: {out_dir}");
 
-    fs::rename(out_path.join(dir_name), out_path.join("mruby")) //
+    fs::rename(out_path.join(dir_name), mruby_dir) //
         .inspect_err(|e| {
             println!("cargo:warning=Failed to rename to mruby;\n Err: {e}")
         })?;

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, io, path::Path};
+use std::{env, fs, path::Path};
 
 use anyhow::{bail, Result};
 use minutus_mruby_build_utils::MRubyManager;
@@ -78,75 +78,30 @@ fn main() -> Result<()> {
         &build_config_copy,
     )?;
 
-    let do_link = env::var("CARGO_FEATURE_LINK_MRUBY").is_ok();
-    let do_download = match env::var("CARGO_FEATURE_MRUBY_DIR") {
-        Err(_) => true,
-        _ => match env::var("MINUTUS_MRUBY_DIR") {
-            Ok(dir) if dir.trim().is_empty() => true,
-            // copy_dir ok => No need to download.
-            // copy_dir err => need to download.
-            Ok(dir) => copy_to_mruby_outdir(&dir, &out_dir).is_err(),
-            _ => true,
-        },
-    };
-
-    MRubyManager::new()
-        .mruby_version(&mruby_version())
-        .link(do_link)
-        .build_config(&build_config_copy)
-        .download(do_download)
-        .run();
+    init_mruby_manager(&build_config_copy)?.run();
     compile_bridge()?;
-
     println!("Finish build.rs");
 
     Ok(())
 }
 
-fn dir_is_not_empty<P: AsRef<Path>>(path: P) -> bool {
-    fs::read_dir(path)
-        .ok()
-        .and_then(|mut entries| entries.next())
-        .is_some()
-}
+fn init_mruby_manager(build_config_copy: &Path) -> Result<MRubyManager> {
+    let do_link = env::var("CARGO_FEATURE_LINK_MRUBY").is_ok();
 
-fn copy_to_mruby_outdir(
-    local_dir: &str,
-    out_dir: &str,
-) -> fs_extra::error::Result<u64> {
-    use fs_extra::dir::{copy as copy_dir, CopyOptions};
+    let mut manager = MRubyManager::new() // We cannot provide proper `mruby_version` if mruby_dir feature is used.
+        .link(do_link)
+        .build_config(build_config_copy);
 
-    let out_path = Path::new(out_dir);
-    let mruby_dir = out_path.join("mruby");
+    manager = if env::var("CARGO_FEATURE_MRUBY_DIR").is_ok() {
+        let mruby_dir = env::var("MINUTUS_MRUBY_DIR")?;
+        manager
+            .download(false)
+            .copy_mruby_from(mruby_dir)
+    } else {
+        manager.mruby_version(&mruby_version())
+    };
 
-    if mruby_dir.exists() {
-        match dir_is_not_empty(&mruby_dir) {
-            true => {
-                println!("cargo:warning=Dir exists: {mruby_dir:?}");
-                return Ok(0);
-            }
-            _ => fs::remove_dir_all(&mruby_dir)?,
-        }
-    }
-
-    let opts = CopyOptions::new().overwrite(true);
-    println!("cargo:warning=local mruby dir: {local_dir}");
-
-    let status = copy_dir(local_dir, out_dir, &opts).inspect_err(|e| {
-        println!("cargo:warning=Failed to copy dir;\n outdir: {out_dir};\n Err: {e}")
-    });
-
-    let dir_name = Path::new(local_dir)
-        .file_name()
-        .ok_or_else(|| io::Error::other("Failed to get local_dir.file_name"))?;
-
-    println!("cargo:warning=out_dir: {out_dir}");
-
-    fs::rename(out_path.join(dir_name), mruby_dir) //
-        .inspect_err(|e| {
-            println!("cargo:warning=Failed to rename to mruby;\n Err: {e}")
-        })?;
-    status
+    Ok(manager)
 }
 
 fn mruby_version() -> String {

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -103,19 +103,25 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn copy_to_mruby_outdir(dir: &str, out_dir: &str) -> fs_extra::error::Result<u64> {
+fn copy_to_mruby_outdir(
+    local_dir: &str,
+    out_dir: &str,
+) -> fs_extra::error::Result<u64> {
     use fs_extra::dir::{copy as copy_dir, CopyOptions};
     let opts = CopyOptions::new().overwrite(true);
-    println!("cargo:warning=local mruby dir: {dir}");
+    println!("cargo:warning=local mruby dir: {local_dir}");
 
-    let status = copy_dir(dir, out_dir, &opts).inspect_err(|e| {
+    let status = copy_dir(local_dir, out_dir, &opts).inspect_err(|e| {
         println!("cargo:warning=Failed to copy dir;\n outdir: {out_dir};\n Err: {e}")
     });
+    let out_path = Path::new(out_dir);
 
-    let dir_name = Path::new(out_dir)
+    let dir_name = Path::new(local_dir)
         .file_name()
-        .ok_or_else(|| io::Error::other("Failed to get out_dir.file_name"))?;
-    fs::rename(dir_name, "mruby")?;
+        .ok_or_else(|| io::Error::other("Failed to get local_dir.file_name"))?;
+
+    println!("cargo:warning=local dir name: {dir_name:?}");
+    fs::rename(out_path.join(dir_name), out_path.join("mruby"))?;
     status
 }
 

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -1,7 +1,6 @@
-use anyhow::{anyhow, Result};
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
+use anyhow::{bail, Result};
 use minutus_mruby_build_utils::MRubyManager;
 
 fn check_command(cmd: &[&str]) {
@@ -24,7 +23,7 @@ fn extract_mruby_source_code() -> Result<()> {
         .join(format!("{}.tar.gz", mruby_version()));
     if !archive_path.exists() {
         println!("cargo:warning={} does not exist", archive_path.display());
-        return Err(anyhow!("{} does not exist", archive_path.display()));
+        bail!("{archive_path:?} does not exist")
     }
 
     if workdir.join("mruby").exists() {
@@ -37,7 +36,7 @@ fn extract_mruby_source_code() -> Result<()> {
         flate2::read::GzDecoder::new(tar_gz.reader())
     };
     let mut archive = tar::Archive::new(tar);
-    archive.unpack(&workdir).unwrap();
+    archive.unpack(workdir).unwrap();
 
     std::fs::rename(
         workdir.join(format!("mruby-{}", mruby_version())),
@@ -75,7 +74,7 @@ fn main() -> Result<()> {
     let out_dir = env::var("OUT_DIR")?;
     let build_config_copy = Path::new(&out_dir).join("build_config.rb");
     std::fs::copy(
-        &env::current_dir()?.join("build_config.rb"),
+        env::current_dir()?.join("build_config.rb"),
         &build_config_copy,
     )?;
 
@@ -95,7 +94,7 @@ fn main() -> Result<()> {
 fn mruby_version() -> String {
     let default = "3.3.0";
     let supported_versions = &["3.1.0", "3.2.0", "3.3.0", "MASTER"];
-    for version in supported_versions.into_iter() {
+    for version in supported_versions {
         if env::var(format!(
             "CARGO_FEATURE_MRUBY_{}",
             str::replace(version, ".", "_")
@@ -105,7 +104,7 @@ fn mruby_version() -> String {
             return version.to_lowercase().to_string();
         }
     }
-    return default.to_string();
+    default.to_string()
 }
 
 fn compile_bridge() -> Result<()> {
@@ -113,7 +112,7 @@ fn compile_bridge() -> Result<()> {
     let out_dir = Path::new(&out_dir);
     // generate bridge.c
     let output = std::process::Command::new("ruby")
-        .args(&["all.rb"])
+        .args(["all.rb"])
         .current_dir(Path::new("src").join("bridge"))
         .output();
     let output = match output {
@@ -125,7 +124,7 @@ fn compile_bridge() -> Result<()> {
     };
     if !output.status.success() {
         eprintln!("{}", String::from_utf8(output.stderr)?);
-        return Err(anyhow!("Failed to execute command"));
+        bail!("Failed to execute command")
     }
 
     let existing_bridge = std::fs::read(out_dir.join("bridge.c"));

--- a/minutus/build.rs
+++ b/minutus/build.rs
@@ -108,6 +108,7 @@ fn copy_to_mruby_outdir(
     out_dir: &str,
 ) -> fs_extra::error::Result<u64> {
     use fs_extra::dir::{copy as copy_dir, CopyOptions};
+
     let opts = CopyOptions::new().overwrite(true);
     println!("cargo:warning=local mruby dir: {local_dir}");
 
@@ -120,8 +121,12 @@ fn copy_to_mruby_outdir(
         .file_name()
         .ok_or_else(|| io::Error::other("Failed to get local_dir.file_name"))?;
 
-    println!("cargo:warning=local dir name: {dir_name:?}");
-    fs::rename(out_path.join(dir_name), out_path.join("mruby"))?;
+    println!("cargo:warning=out_dir: {out_dir}");
+
+    fs::rename(out_path.join(dir_name), out_path.join("mruby")) //
+        .inspect_err(|e| {
+            println!("cargo:warning=Failed to rename to mruby;\n Err: {e}")
+        })?;
     status
 }
 


### PR DESCRIPTION
1. Adding a `Default` implementation for `MRubyManager` was suggested by `cargo clippy`. Honestly, I recommend running `cargo clippy` manually. 

2.
Some documentation comments are automatically wrapped to the next line due to excessive width. This does not affect the final display. For more precise formatting, please provide a `.rustfmt.toml` file in the project root.

3.
- old: `self.mruby_version.map(String::from)`
- new: `self.mruby_version`

Since mruby_version is already of type `Option<String>`, using map here is unnecessary.

4.

`return Err(anyhow!(format!("{fmt}")))` => `bail!("{fmt}")`

It can be simplified.  
 
This is the basic API usage of `anyhow`.
I'm surprised you don't know it.

Close #24 