### PR TITLE
chore(build-utils): simplify error handling for `copy_to_mruby_dir()`

### DIFF
--- a/minutus-mruby-build-utils/src/lib.rs
+++ b/minutus-mruby-build-utils/src/lib.rs
@@ -108,16 +108,9 @@ impl MRubyManager {
         }
 
         if let Some(src_dir) = self.copy_mruby_from {
-            let copied =
-        mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|_| {
-          panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby")
-        });
-            if copied == 0 {
-                panic!(
-                    r#"No files were copied into the `mruby` directory.
-          Please make sure that mruby src dir is not an empty directory."#
-                )
-            }
+            mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|e| {
+                panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby\n Error: {e}")
+            })
         }
 
         build_mruby(&workdir, &build_config);

--- a/minutus-mruby-build-utils/src/lib.rs
+++ b/minutus-mruby-build-utils/src/lib.rs
@@ -108,7 +108,7 @@ impl MRubyManager {
         }
 
         if let Some(src_dir) = self.copy_mruby_from {
-            mruby_dir::copy_to_mruby_dir(&src_dir, &workdir).unwrap_or_else(|e| {
+            mruby_dir::copy_to_mruby_dir(&src_dir, &workdir, 4096).unwrap_or_else(|e| {
                 panic!("Failed to copy dir. src: {src_dir:?}, target: {workdir:?}/mruby\n Error: {e}")
             })
         }

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -1,4 +1,4 @@
-use std::{fs, io, path::Path};
+use std::{borrow::Cow, fs, io, path::Path};
 
 use fs_extra::{
     dir::{copy as copy_dir, CopyOptions},
@@ -62,7 +62,17 @@ fn try_to_copy_dir(from: &Path, to: &Path) -> FsResult<u64> {
 /// - If `target_dir` exists and contains files, returns `Ok(())`.
 /// - If the total size of data copied from `src_dir` to `target_dir` is zero
 ///   bytes, returns `Err`.
-pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> FsResult<()> {
+///
+/// - `min_required_size` defines the minimum required size of copied data, in
+///   bytes.
+///   - If the actual copied size is too small (e.g., < 4 KiB), it is assumed
+///     that `src_dir` does not contain a complete mruby source tree. To disable
+///     this check, set `min_required_size` to 0.
+pub(crate) fn copy_to_mruby_dir(
+    src_dir: &Path,
+    work_dir: &Path,
+    min_required_size: u64,
+) -> FsResult<()> {
     let target_dir = work_dir.join("mruby");
 
     if target_dir.exists() {
@@ -82,9 +92,24 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> FsResult<()>
 
     let copied = try_to_copy_dir(src_dir, &target_dir)?;
 
-    if copied == 0 {
-        let err_msg = r#"No files were copied into the `mruby` directory.
+    if copied < min_required_size {
+        let no_files_err = r#"No files were copied into the `mruby` directory.
     Please make sure that mruby src dir is not an empty directory."#;
+
+        let err_msg = match copied {
+            0 => no_files_err.into(),
+            n => {
+                let msg = format!(
+                    "The copied data size from {src_dir:?} appears to be too small.
+        > Expected at least: {min_required_size} bytes;
+        > Actual: {n} bytes.
+        Please verify that the directory contains a valid mruby source tree.
+        If you suspect this is a bug, feel free to report an issue."
+                );
+                Cow::from(msg)
+            }
+        };
+
         let fs_err = io::Error::other(err_msg).into();
         return Err(fs_err);
     }

--- a/minutus-mruby-build-utils/src/mruby_dir.rs
+++ b/minutus-mruby-build-utils/src/mruby_dir.rs
@@ -1,6 +1,9 @@
 use std::{fs, io, path::Path};
 
-use fs_extra::dir::{copy as copy_dir, CopyOptions};
+use fs_extra::{
+    dir::{copy as copy_dir, CopyOptions},
+    error::Result as FsResult,
+};
 
 /// Checks whether a directory is empty.
 ///
@@ -19,22 +22,28 @@ fn dir_is_not_empty<P: AsRef<Path>>(path: P) -> bool {
         .is_some()
 }
 
-fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
+/// Recursively copy a single directory. (behavior similar to `cp -rf` on Unix)
+/// See also: [fs_extra::dir::copy]
+///
+/// # Returns
+///
+/// This function returns [`fs_extra::error::Result<u64>`].
+///
+/// When returning `Ok(n)`, `n` represents the amount of data transferred (in
+/// bytes).
+///
+/// - If `n = 0`, it means an empty directory was copied.
+/// - If `n >= 1`, it indicates that a non-empty directory was transferred
+///   (copied).
+fn try_to_copy_dir(from: &Path, to: &Path) -> FsResult<u64> {
     let opts = CopyOptions::new()
         .overwrite(true)
         .copy_inside(true);
 
-    copy_dir(from, to, &opts).map_err(|e| {
-        let err_msg = format!(
-            "Failed to copy directory.
-            src dir: {from:?}, target dir: {to:?}
-            Err: {e}"
-        );
-        io::Error::other(err_msg)
-    })
+    copy_dir(from, to, &opts)
 }
 
-/// Copies the "/path/to/mruby-src-dir" to "work_dir/mruby"
+/// Copies the "/path/to/mruby-src-dir" to "{work_dir}/mruby"
 ///
 /// # Example
 ///
@@ -46,32 +55,22 @@ fn try_to_copy_dir(from: &Path, to: &Path) -> io::Result<u64> {
 /// copy_to_mruby_dir(src_dir, &work_dir)?;
 /// ```
 ///
-/// # Returns
+/// # Notes
 ///
-/// This function returns either `io::ErrorKind::Other(msg)` or `Ok(u64)`.
+/// > target_dir: "{work_dir}/mruby"
 ///
-/// When returning `Ok(n)`, `n` represents the amount of data transferred (in
-/// bytes).
-///
-/// - If `n = 0`, it means an empty directory was copied.
-/// - If `n >= 1`, it indicates that a non-empty directory was transferred
-///   (copied).
-///
-/// > Note: This function uses the special return value `Ok(1)` to indicate that
-/// > `target_dir` already exists and is not empty, but the function returned
-/// > early without performing any copy operation.
-pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u64> {
+/// - If `target_dir` exists and contains files, returns `Ok(())`.
+/// - If the total size of data copied from `src_dir` to `target_dir` is zero
+///   bytes, returns `Err`.
+pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> FsResult<()> {
     let target_dir = work_dir.join("mruby");
 
     if target_dir.exists() {
         if dir_is_not_empty(&target_dir) {
             eprintln!("[INFO] Dir exists: {target_dir:?}");
-            // Do not use Ok(0) here.
-            // Later, we might need to use Ok(n) to determine the number of bytes copied.
-            // In some cases, OK(0) (i.e., copying an empty directory) may be considered a
-            // failure. Therefore, we use `Ok(1)`.
-            return Ok(1);
+            return Ok(());
         }
+
         // An existing but empty mruby directory is a clear sign of a failed or
         // incomplete build.
         // Perform cleanup at this stage to prevent issues with subsequent `dir::copy`
@@ -81,7 +80,14 @@ pub(crate) fn copy_to_mruby_dir(src_dir: &Path, work_dir: &Path) -> io::Result<u
     }
     eprintln!("[INFO] src dir: {src_dir:?}, target dir: {target_dir:?}");
 
-    // There's no need to check whether `src_dir` is an empty directory here;
-    // instead, let the final caller handle the Err(_) & Ok(0).
-    try_to_copy_dir(src_dir, &target_dir)
+    let copied = try_to_copy_dir(src_dir, &target_dir)?;
+
+    if copied == 0 {
+        let err_msg = r#"No files were copied into the `mruby` directory.
+    Please make sure that mruby src dir is not an empty directory."#;
+        let fs_err = io::Error::other(err_msg).into();
+        return Err(fs_err);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
genya0407 [said](https://github.com/genya0407/minutus/pull/32#discussion_r2508131944):

> I don't fully agree with the necessity of `u64`.
> If `Ok(0)` results in `panic!`, it should be `Err` not `Ok`.

@genya0407 I submitted this PR just to make you happy.
Personally, I believe that mutual respect is essential in any collaboration. 
Maintainers should avoid placing undue burdens on contributors, and contributors should likewise respect the decisions and preferences of the main maintainers.